### PR TITLE
add TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ $loop->run();
 * `vhost`: Virtual host, defaults to `/`.
 * `login`: Login user name, defaults to `guest`.
 * `passcode`: Login passcode, defaults to `guest`.
+* `protocol`: Protocol to connect with, defaults to `tcp` (use `tls` for TLS-enabled connections).
 
 ## Acknowledgement
 
@@ -94,6 +95,10 @@ $client->subscribeWithAck('/topic/foo', 'client', function ($frame, $ackResolver
 To run the test suite, you need PHPUnit.
 
     $ phpunit
+
+Or, to run the functional tests against a local message queue:
+
+    $ STOMP_PROVIDER=rabbitmq phpunit -c phpunit-functional.xml.dist
 
 ## License
 

--- a/examples/config/activemq-tls.php
+++ b/examples/config/activemq-tls.php
@@ -1,0 +1,10 @@
+<?php
+
+return array(
+    'host'     => '127.0.0.1',
+    'port'     => '61614',
+    'login'    => 'system',
+    'passcode' => 'manager',
+    'vhost'    => '/',
+    'protocol' => 'tls',
+);

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -17,6 +17,7 @@ class Factory
         'vhost'     => '/',
         'login'     => 'guest',
         'passcode'  => 'guest',
+        'protocol'  => 'tcp',
     );
 
     private $loop;
@@ -51,7 +52,7 @@ class Factory
 
     public function createConnection($options)
     {
-        $address = 'tcp://'.$options['host'].':'.$options['port'];
+        $address = $options['protocol'].'://'.$options['host'].':'.$options['port'];
 
         if (false === $fd = @stream_socket_client($address, $errno, $errstr)) {
             $message = "Could not bind to $address: $errstr";

--- a/tests/React/Tests/Stomp/FactoryTest.php
+++ b/tests/React/Tests/Stomp/FactoryTest.php
@@ -13,7 +13,7 @@ class FactoryTest extends TestCase
 
         $loop = $this->createMock('React\EventLoop\LoopInterface');
         $factory = new Factory($loop);
-        $conn = $factory->createConnection(array('host' => 'localhost', 'port' => 37234));
+        $conn = $factory->createConnection(array('host' => 'localhost', 'port' => 37234, 'protocol' => 'tcp'));
 
         $this->assertInstanceOf('React\Socket\Connection', $conn);
     }
@@ -25,7 +25,7 @@ class FactoryTest extends TestCase
         $factory = new Factory($loop);
 
         try {
-            $factory->createConnection(array('host' => 'localhost', 'port' => 37235));
+            $factory->createConnection(array('host' => 'localhost', 'port' => 37235, 'protocol' => 'tcp'));
             $this->fail('This should have raised an exception');
         } catch (ConnectionException $e) {
 


### PR DESCRIPTION
This adds the ability to connect to TLS-protected queue brokers, via the 'protocol' option. Update affected unit tests, add functional test (verified against activemq v5.15.0). Also document how to run the functional tests